### PR TITLE
htc-7x30-common: Remove infinite self-inclusion

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
--include device/htc/msm7x30-common/BoardConfigCommon.mk
-
 # inherit from common msm7x30 Recovery
 -include device/htc/7x30-recovery/BoardConfigCommon.mk
 


### PR DESCRIPTION
Same as the following commit - needs to be applied to jellybean branch:

https://github.com/CyanogenMod/android_device_htc_msm7x30-common/commit/39789ecc76cb5516c3093574944cf798ad498a19
